### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui-sound-lab"
+description = "Nodes:Music Gen, Audio Play, Stable Audio"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["torchaudio", "einops>=0.7.0", "einops-exts>=0.0.4", "soundfile>=0.10.2", "aeiou>=0.0.20", "transformers>=4.36.2", "alias-free-torch>=0.0.6", "ema-pytorch>=0.2.3", "encodec>=0.1.1", "x-transformers<1.27.0", "descript-audiotools", "descript-audio-codec>=1.0.0", "k-diffusion"]
+
+[project.urls]
+Repository = "https://github.com/shadowcz007/comfyui-sound-lab"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "comfyui-sound-lab"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!